### PR TITLE
don't talk to pagerduty if not in PROD

### DIFF
--- a/scripts/pagerduty_notify.rb
+++ b/scripts/pagerduty_notify.rb
@@ -31,7 +31,13 @@ PD_URI = URI('https://events.pagerduty.com/generic/2010-04-15/create_event.json'
 
 #START MAIN
 begin
-  check_arguments(['service_key','event_type','message'])
+  # don't talk to pagerduty if not in PROD
+  if(ENV['debug'])
+    exit(0)
+  else
+    check_arguments(['service_key','event_type','message'])
+  end
+
 rescue ArgumentMissing=>e
   puts("-ERROR: You need to specify <#{e.message}> in the route file.")
   exit(1)


### PR DESCRIPTION
alarming in DEV is noisy and noise can distract from real alarms, so lets alarm only in PROD