### PR TITLE
fixes to installer to use packer-built image better

### DIFF
--- a/CDS/install.sh
+++ b/CDS/install.sh
@@ -69,6 +69,7 @@ if [ -x "${APTGET}" ]; then	#We have apt so are running on a debian-type system
 	echo If you are not using apt-provided versions of Perl, Ruby-gems, then you should press
 	echo CTRL-C to stop the install and ensure that they are installed and up to date.
 	echo Then re-run the install and type S \[enter\] here to skip
+	echo Ruby is now NOT installed by default below. You should run apt-get install ruby-{version} once this installer completes.
 	echo
 	echo Most users should type C \[enter\] to continue, and then Y \(yes\) when APT asks you if you want
 	echo to install the packages
@@ -90,7 +91,7 @@ if [ -x "${APTGET}" ]; then	#We have apt so are running on a debian-type system
 	"C" )
         #zlib1g-dev is required for nokogiri in aws-sdk-v1
 		apt-get ${pkgargs} update
-		apt-get ${pkgargs} install perl cpanminus ruby2.0 ruby2.0-dev zlib1g-dev build-essential s3cmd libsqlite3-dev
+		apt-get ${pkgargs} install perl cpanminus zlib1g-dev build-essential s3cmd libsqlite3-dev
 		if [ "$?" != "0" ]; then
 			echo
 			echo -------------------------------------------------------
@@ -252,14 +253,6 @@ if [ "${PRINSTALLED}" == "0" ]; then
 	read junk
 fi
 
-#ensure that system ruby is version 2.0
-#FIXME - need to implement a flag to make this optional
-if [ -x "/usr/bin/ruby2.0" ]; then
-    rm -f /usr/bin/ruby
-    ln -s /usr/bin/ruby2.0 /usr/bin/ruby
-    rm -f /usr/bin/gem
-    ln -s /usr/bin/gem2.0 /usr/bin/gem
-fi
 
 #Attempt to install the AWS SDK for Ruby....
 GEM=`which gem`

--- a/circle.yml
+++ b/circle.yml
@@ -2,13 +2,15 @@
 
 machine:
   ruby:
-    version: ruby-2.0.0
+    version: ruby-2.2.5
   java:
     version: oraclejdk8
     
 checkout:
   post:
-    - sudo ./CDS/install.sh -y
+    - chmod a+x ./circle_setup_rvm.sh
+    - sudo -E ./circle_setup_rvm.sh
+    - sudo -i /home/ubuntu/content_delivery_system/CDS/install.sh -y
 
 test:
   override:

--- a/circle_setup_rvm.sh
+++ b/circle_setup_rvm.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo export PATH="$PATH:/opt/circleci/.rvm/bin" >> /root/.profile
+echo '[[ -s "/opt/circleci/.rvm/scripts/rvm" ]] && source "/opt/circleci/.rvm/scripts/rvm"' >> /root/.profile

--- a/packer/cdsbase/cloud-init-build.sh
+++ b/packer/cdsbase/cloud-init-build.sh
@@ -13,7 +13,7 @@ echo ------------------------------------------
 apt-get -y install python-pip e2fsprogs zip perl ffmpeg2theora libz-dev libcrypt-ssleay-perl liburi-encode-perl libnet-ssleay-perl libnet-idn-encode-perl \
 liblwp-protocol-https-perl libdbd-sqlite3-perl libyaml-perl libxml-sax-expatxs-perl libxml-xpath-perl libwww-perl libtemplate-perl libtemplate-perl-doc \
 libxml-simple-perl libjson-perl libjson-xs-perl libdate-manip-perl libnet-sslglue-perl libdigest-perl libdigest-sha-perl libdatetime-perl libdatetime-format-http-perl \
-libdbi-perl libhtml-stream-perl libfile-slurp-unicode-perl
+libdbi-perl libhtml-stream-perl libfile-slurp-unicode-perl cpanminus zlib1g-dev build-essential s3cmd libsqlite3-dev
 pip install awscli
 
 ###Step 5 - Ruby prerequisited


### PR DESCRIPTION
removing explicit ruby installs in order to use what's on the base box by default, updates to circleci configuration to make it work. Also updating to ruby 2.2.5 as installed on the packer image