### PR TITLE
stopping a crash if static definitions folder does not exist

### DIFF
--- a/CDS/js/Datastore.js
+++ b/CDS/js/Datastore.js
@@ -16,7 +16,11 @@ function Connection(whoami, path) {
 }
 
 function loadDefs(path) {
-    const file_list = fs.readdirSync(path);
+    try {
+        const file_list = fs.readdirSync(path);
+    } catch(e){
+        return {};
+    }
     const is_comment = /^#/;
     const matcher = /^(\w+)\s*=\s*(.*)$/;
 

--- a/CDS/js/test/TestDataStore.js
+++ b/CDS/js/test/TestDataStore.js
@@ -31,6 +31,14 @@ describe('Datastore',function(){
         fs.rmdir(test_data_dir);
     });
 
+    describe('#datastore', function() {
+        it('should not error if the datastore path is not valid', function(done){
+            assert.doesNotThrow(function(){
+                newconn=new datastore.Connection("TestDataStore","/path/that/is/not/valid/conf.d");
+                done();
+            });
+        });
+    });
     describe('#set', function(){
         it('should store a value to meta and return nothing', function(done){
             datastore.set(conn,'meta','key','something').done(function(value){


### PR DESCRIPTION
@Reettaphant 
static defs are returned as empty if they do not exist; this is expected behaviour