### PR TITLE
refactor poster image logic to work with urls

### DIFF
--- a/CDS/scripts/js_utils/test/youtube/TestYoutubeLib.js
+++ b/CDS/scripts/js_utils/test/youtube/TestYoutubeLib.js
@@ -92,6 +92,8 @@ describe('YoutubeUpload', () => {
 
     describe('#getMetadata', () => {
 
+        const categoryId = 22;
+
         var dataStoreStub, stringSubstituteStub;
 
         beforeEach(() => {
@@ -101,7 +103,7 @@ describe('YoutubeUpload', () => {
                     fulfill({
                         key: key,
                         type: type,
-                        value: key == 'atom_category' ? 22 : key
+                        value: key == 'atom_category' ? categoryId : key
                     });
                 });
             });
@@ -131,7 +133,7 @@ describe('YoutubeUpload', () => {
 
                 assert.equal(snippet.title, 'atom_title');
                 assert.equal(snippet.description, 'atom_description');
-                assert.equal(snippet.categoryId, 22);
+                assert.equal(snippet.categoryId, categoryId);
                 assert.equal(snippet.tags, 'keywords');
                 assert.equal(status, 'status');
                 sinon.assert.callCount(dataStoreStub, 4);

--- a/CDS/scripts/js_utils/test/youtube/TestYoutubeLib.js
+++ b/CDS/scripts/js_utils/test/youtube/TestYoutubeLib.js
@@ -98,7 +98,11 @@ describe('YoutubeUpload', () => {
             process.env.access = 'status';
             dataStoreStub = sinon.stub(dataStore, 'get', (connection, type, key) => {
                 return new Promise(fulfill => {
-                    fulfill({ value: key });
+                    fulfill({
+                        key: key,
+                        type: type,
+                        value: key == 'atom_category' ? 22 : key
+                    });
                 });
             });
 
@@ -127,7 +131,7 @@ describe('YoutubeUpload', () => {
 
                 assert.equal(snippet.title, 'atom_title');
                 assert.equal(snippet.description, 'atom_description');
-                assert.equal(snippet.categoryId, 'category_id');
+                assert.equal(snippet.categoryId, 22);
                 assert.equal(snippet.tags, 'keywords');
                 assert.equal(status, 'status');
                 sinon.assert.callCount(dataStoreStub, 4);
@@ -198,14 +202,12 @@ describe('YoutubeUpload', () => {
 
 
         it('should upload to youtube', () => {
-
-            return youtubeUpload.uploadToYoutube()
-            .then((result) => {
+            youtubeUpload.uploadToYoutube().then((result) => {
                 sinon.assert.calledOnce(authStub);
                 sinon.assert.calledOnce(youtubeStub);
                 sinon.assert.calledOnce(dataStub);
                 assert.equal(result.id, 'id');
-                return;
+                done();
             });
         });
     });

--- a/CDS/scripts/js_utils/youtube/youtube-upload-lib.js
+++ b/CDS/scripts/js_utils/youtube/youtube-upload-lib.js
@@ -1,9 +1,10 @@
-var Promise = require('promise');
-var fs = require('fs');
-var youtubeAuth = require('./youtube-auth.js');
-var googleapis = require('googleapis');
-var OAuth2 = googleapis.auth.OAuth2;
-var dataStore = require('../Datastore');
+const Promise = require('promise');
+const fs = require('fs');
+const youtubeAuth = require('./youtube-auth.js');
+const googleapis = require('googleapis');
+const OAuth2 = googleapis.auth.OAuth2;
+const dataStore = require('../Datastore');
+const https = require('https');
 
 const YOUTUBE_API_VERSION = 'v3';
 
@@ -68,25 +69,49 @@ function getYoutubeData(connection) {
     });
 }
 
-function addPosterImageIfExists(connection, videoId, youtubeClient, account) {
-    return dataStore.get(connection, 'meta', 'poster_image')
-    .then(file => {
+function isSecureUrl(maybeSecure) {
+    return maybeSecure.startsWith('https://');
+}
 
-        if (file.value && file.value!='(value not found)') {
-
-          if (!account) {
-            return new Promise((fulfill, reject) => { reject( new Error('could not add a poster image: missing account owner') )});
-          }
-          return  new Promise((fulfill, reject) => {
-            youtubeClient.thumbnails.set({ videoId: videoId, onBehalfOfContentOwner: account, media: {body: fs.createReadStream(file.value)}}, (err, result) => {
-                  if (err) reject(err);
-                  else fulfill(result);
-            });
-          });
-        } else {
-          console.warn("No poster image present in metadata key poster_image");
+function downloadPosterImage(url, dest) {
+    return new Promise((resolve, reject) => {
+        if (! isSecureUrl(url)) {
+            reject('No https poster image in metadata');
         }
-        return new Promise(fulfill => {fulfill()});
+
+        const file = fs.createWriteStream(dest);
+
+        https.get(url, (response) => {
+            response.pipe(file);
+            file.on('finish', () => file.close(resolve(dest)));
+        }).on('error', (err) => {
+            fs.unlink(file);
+            reject(err);
+        });
+    });
+}
+
+function addPosterImageIfExists(connection, videoId, youtubeClient, account) {
+    return new Promise((resolve, reject) => {
+        if (! account) {
+            reject(new Error('could not add a poster image: missing account owner'));
+        }
+
+        dataStore.get(connection, 'meta', 'poster_image').then(posterImage => {
+            downloadPosterImage(posterImage.value, `/tmp/${videoId}.jpg`).then(filename => {
+                const payload = {
+                    videoId: videoId,
+                    onBehalfOfContentOwner: account,
+                    media: {
+                        body: fs.createReadStream(filename)
+                    }
+                };
+
+                youtubeClient.thumbnails.set(payload, (err, result) => err ? reject(err) : resolve(result));
+            }).catch(err => {
+                reject(err);
+            });
+        });
     });
 }
 

--- a/CDS/scripts/media-atom-youtube-upload.js
+++ b/CDS/scripts/media-atom-youtube-upload.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 //This method uploads the video specified in the cnf_media_file parameter to youtube.
+//It expects the following datastore keys to be set:
+//  poster_image - URL location of a poster image to upload to Youtube
 //It expects the following arguments:
 //<client_secrets> - path to the client secrets file with client id, client secret and client email
 //<private_key> path to encrypted private key file
@@ -9,7 +11,7 @@
 //<access> - the level of access for the video
 //<owner_channel> - [OPTIONAL] the channel you are uploading to
 //<owner_account> - [OPTIONAL] The account that the video is uploaded on behalf of. You can ommit the channel and owner_account parameters, but this means you cannot upload videos of accounts with multiple channels. If you specify the channel to upload to, then you must also specify the owner account you are uploading on behalf of.
-
+//<poster_image_dir>/path/to/poster/image - [OPTIONAL] - Scratch location to download poster images to, when they come as a URL
 var youtubeLib = require('./js_utils/youtube/youtube-upload-lib');
 var dataStore = require('./js_utils/Datastore');
 


### PR DESCRIPTION
Previously, we were creating a read stream from a url, which is not possible. Now, we download the file to `/tmp/videoid.jpg` then create a read stream from that.

cc @fredex42 @clloyd @Reettaphant 