### PR TITLE
DataStore Config as an ES6 class

### DIFF
--- a/CDS/scripts/js_utils/datastore/config.js
+++ b/CDS/scripts/js_utils/datastore/config.js
@@ -4,25 +4,23 @@ const PropertiesReader = require('properties-reader');
 
 class Config {
     constructor (configDirectory = '/etc/cds_backend/conf.d', namespaceChar = '_') {
-        const self = this;
+        this.configDirectory = configDirectory;
+        this.namespaceChar = namespaceChar;
 
-        self.configDirectory = configDirectory;
-        self.namespaceChar = namespaceChar;
-
-        const baseConfig = self._getEnvironmentConfig();
+        const baseConfig = this._getEnvironmentConfig();
 
         try {
-            self.config = fs.readdirSync(self.configDirectory)
+            this.config = fs.readdirSync(this.configDirectory)
                 .filter(f => f.endsWith('.conf'))
                 .reduce((properties, fileName) => {
-                    const filePath = path.join(self.configDirectory, fileName);
+                    const filePath = path.join(this.configDirectory, fileName);
                     const props = PropertiesReader(filePath).getAllProperties();
-                    return Object.assign({}, properties, self._namespaceConfig(props, 'config'));
+                    return Object.assign({}, properties, this._namespaceConfig(props, 'config'));
                 }, baseConfig);
         }
         catch (e) {
-            // cannot read files in `self.configDirectory`
-            self.config = baseConfig;
+            // cannot read files in `this.configDirectory`
+            this.config = baseConfig;
         }
     }
 
@@ -47,17 +45,14 @@ class Config {
     }
 
     _namespaceConfig (config, namespace) {
-        const self = this;
         return Object.keys(config).reduce((result, key) => {
-            result[`${namespace}${self.namespaceChar}${key}`] = config[key];
+            result[`${namespace}${this.namespaceChar}${key}`] = config[key];
             return result;
         }, {});
     }
 
     withDateConfig (date = new Date()) {
-        const self = this;
-
-        return Object.assign({}, self.config, {
+        return Object.assign({}, this.config, {
             'year': date.getFullYear(),
             'month': date.getMonth() + 1,
             'day': date.getDate(),

--- a/CDS/scripts/js_utils/datastore/config.js
+++ b/CDS/scripts/js_utils/datastore/config.js
@@ -1,0 +1,71 @@
+const path = require('path');
+const fs = require('fs');
+const PropertiesReader = require('properties-reader');
+
+class Config {
+    constructor (configDirectory = '/etc/cds_backend/conf.d', namespaceChar = '_') {
+        const self = this;
+
+        self.configDirectory = configDirectory;
+        self.namespaceChar = namespaceChar;
+
+        const baseConfig = self._getEnvironmentConfig();
+
+        try {
+            self.config = fs.readdirSync(self.configDirectory)
+                .filter(f => f.endsWith('.conf'))
+                .reduce((properties, fileName) => {
+                    const filePath = path.join(self.configDirectory, fileName);
+                    const props = PropertiesReader(filePath).getAllProperties();
+                    return Object.assign({}, properties, self._namespaceConfig(props, 'config'));
+                }, baseConfig);
+        }
+        catch (e) {
+            // cannot read files in `self.configDirectory`
+            self.config = baseConfig;
+        }
+    }
+
+    _getEnvironmentConfig () {
+        const conf = {};
+
+        if (process && process.env) {
+            if (process.env.cf_route_name) {
+                conf.route_name = process.env.cf_route_name;
+            }
+
+            if (process.env.HOSTNAME) {
+                conf.hostname = process.env.HOSTNAME;
+            }
+
+            if (process.env.OSTYPE) {
+                conf.ostype = process.env.OSTYPE;
+            }
+        }
+
+        return conf;
+    }
+
+    _namespaceConfig (config, namespace) {
+        const self = this;
+        return Object.keys(config).reduce((result, key) => {
+            result[`${namespace}${self.namespaceChar}${key}`] = config[key];
+            return result;
+        }, {});
+    }
+
+    withDateConfig (date = new Date()) {
+        const self = this;
+
+        return Object.assign({}, self.config, {
+            'year': date.getFullYear(),
+            'month': date.getMonth() + 1,
+            'day': date.getDate(),
+            'hour': date.getHours(),
+            'min': date.getMinutes(),
+            'sec': date.getSeconds()
+        });
+    }
+}
+
+module.exports = Config;

--- a/CDS/scripts/js_utils/package.json
+++ b/CDS/scripts/js_utils/package.json
@@ -9,6 +9,7 @@
     "mocha": "3.1.2",
     "pem": "^1.8.3",
     "promise": "7.1.1",
+    "properties-reader": "0.0.15",
     "q": "^1.4.1",
     "reqwest": "^2.0.5",
     "sqlite3": "3.1.6",

--- a/CDS/scripts/js_utils/test/data/config.conf
+++ b/CDS/scripts/js_utils/test/data/config.conf
@@ -1,0 +1,4 @@
+# this is a comment
+username = foo
+password = bar
+something_else = baz

--- a/CDS/scripts/js_utils/test/datastore/config.js
+++ b/CDS/scripts/js_utils/test/datastore/config.js
@@ -1,0 +1,60 @@
+const assert = require('assert');
+const path = require('path');
+const Config = require('../../datastore/config');
+
+const dataDir = path.join(__dirname, '../data');
+
+describe('DataStore Config', () => {
+    it('should read config files from disk', (done) => {
+        const c = new Config(dataDir);
+
+        const expected = {
+            config_username: 'foo',
+            config_password: 'bar',
+            config_something_else: 'baz'
+        };
+
+        const actual = c.config;
+
+        assert.deepEqual(actual, expected);
+        done();
+    });
+
+    it('should read obey the custom namespace char', (done) => {
+        const c = new Config(dataDir, ':');
+
+        const expected = {
+            'config:username': 'foo',
+            'config:password': 'bar',
+            'config:something_else': 'baz'
+        };
+
+        const actual = c.config;
+
+        assert.deepEqual(actual, expected);
+        done();
+    });
+
+    it('should add extra properties when .withDateConfig is called', (done) => {
+        const c = new Config(dataDir);
+
+        const date = new Date("2016-01-01 00:00:00");
+
+        const actual = c.withDateConfig(date);
+
+        const expected = {
+            config_username: 'foo',
+            config_password: 'bar',
+            config_something_else: 'baz',
+            year: 2016,
+            month: 1,
+            day: 1,
+            hour: 0,
+            min: 0,
+            sec: 0
+        };
+
+        assert.deepEqual(actual, expected);
+        done();
+    });
+});


### PR DESCRIPTION
ES6 Config class

Replaces the [loadDefs function in Datastore.js](https://github.com/guardian/content_delivery_system/blob/master/CDS/scripts/js_utils/Datastore.js#L20-L54), using the properties-reader library to parse files.

NB - we're not using this class yet (other than in tests)