### PR TITLE
media atom es6

### DIFF
--- a/CDS/scripts/js_utils/media-atom/hmac.js
+++ b/CDS/scripts/js_utils/media-atom/hmac.js
@@ -1,0 +1,63 @@
+const crypto = require('crypto');
+const reqwest = require('reqwest');
+
+class HMACRequest {
+    constructor (configObj) {
+        const requiredConfig = ['shared_secret'];
+
+        requiredConfig.forEach(c => {
+            if (! Object.keys(configObj.config).includes(c)) {
+                throw `Invalid Config. Missing ${c}`;
+            }
+        });
+
+        this.configObj = configObj;
+
+        this.sharedSecret = this.configObj.config.shared_secret;
+    }
+
+    _getToken (url, date) {
+        const hmac = crypto.createHmac('sha256', this.sharedSecret);
+        const content = [date, url].join('\n');
+
+        hmac.update(content, 'utf-8');
+
+        return `HMAC ${hmac.digest('base64')}`;
+    }
+
+    _request (url, method, data = {}) {
+        const date = new Date().toUTCString();
+        const token = this._getToken(url, date);
+
+        const requestBody = {
+            url: url,
+            method: method,
+            contentType: 'application/json',
+            headers: {
+                'X-Gu-Tools-HMAC-Date': date,
+                'X-Gu-Tools-HMAC-Token': token,
+                'X-Gu-Tools-Service-Name': 'content_delivery_system'
+            }
+        };
+
+        if (Object.keys(data).length > 0) {
+            requestBody.data = JSON.stringify(data);
+        }
+
+        return reqwest(requestBody);
+    }
+
+    get (url) {
+        return this._request(url, 'GET');
+    }
+
+    post (url, data) {
+        return this._request(url, 'POST', data);
+    }
+
+    put (url, data) {
+        return this._request(url, 'PUT', data);
+    }
+}
+
+module.exports = HMACRequest;

--- a/CDS/scripts/js_utils/media-atom/media-atom.js
+++ b/CDS/scripts/js_utils/media-atom/media-atom.js
@@ -1,0 +1,105 @@
+const MediaAtomModel = require('./model/media-atom-model');
+
+class MediaAtom {
+    constructor (cdsModel, configObj, hmacRequest, apiPollDuration = 5 * 60 * 1000, apiPollInterval = 60 * 1000) {
+        if (! Object.keys(configObj.config).includes('media_atom_url_base')) {
+            throw `Invalid Config. Missing media_atom_url_base`;
+        }
+
+        this.cdsModel = cdsModel;
+        this.configObj = configObj;
+        this.hmacRequest = hmacRequest;
+        this.atomApiDomain = this.configObj.config.media_atom_url_base;
+
+        this.atomApiPaths = {
+            asset: `/api2/atoms/:id/assets`,
+            metadata: '/api2/atoms/:id',
+            activateAsset: '/api2/atom/:id/asset-active'
+        };
+
+        this.apiPollDuration = apiPollDuration;
+        this.apiPollInterval = apiPollInterval;
+    }
+
+    _getUrl (path, atomId) {
+        return `${this.atomApiDomain}${path}`.replace(/:id/, atomId);
+    }
+
+    fetchAndSaveMetadata () {
+        return new Promise ((resolve, reject) => {
+            this.cdsModel.getData().then(cdsModel => {
+                if (! cdsModel.atomId) {
+                    reject('Failed to get atomId from database');
+                }
+
+                const url = this._getUrl(this.atomApiPaths.metadata, cdsModel.atomId);
+
+                this.hmacRequest.get(url).then(response => {
+                    const model = new MediaAtomModel(response);
+
+                    model.validate().then(atomModel => {
+                        this.cdsModel.saveAtomModel(atomModel).then(() => {
+                            resolve(response);
+                        });
+                    }).catch(missingFields => {
+                        reject(`Invalid response from Atom API. Missing ${missingFields.join(',')}`);
+                    });
+                });
+            });
+        });
+    }
+
+    _httpPoll (url, data, timeoutMessage) {
+        const self = this; // to avoid `.bind(this)`
+
+        const endTime = Number(new Date()) + this.apiPollDuration;
+
+        function checkCondition (resolve, reject) {
+            self.hmacRequest.put(url, data)
+                .then(response => resolve(response))
+                .catch(() => {
+                    if (Number(new Date()) < endTime) {
+                        setTimeout(checkCondition, self.apiPollInterval, resolve, reject);
+                    } else {
+                        reject(timeoutMessage);
+                    }
+                });
+        }
+
+        return new Promise(checkCondition);
+    }
+
+    activateAsset () {
+        const timeoutMessage = 'Cannot add asset to youtube, video encoding took too long';
+
+        return new Promise((resolve, reject) => {
+            this.cdsModel.getData().then(cdsModel => {
+                if (!cdsModel.youtubeId) {
+                    reject('Failed to get youtubeId from database');
+                }
+
+                const data = { youtubeId: cdsModel.youtubeId };
+                const url = this._getUrl(this.atomApiPaths.activateAsset, cdsModel.atomId);
+
+                this._httpPoll(url, data, timeoutMessage)
+                    .then(response => resolve(response))
+                    .catch(e => reject(e));
+            });
+        });
+    }
+
+    addAsset () {
+        return this.cdsModel.getData().then(cdsModel => {
+           if (! cdsModel.youtubeId) {
+               reject('Failed to get youtubeId from database');
+           }
+
+            const data = { uri: `https://www.youtube.com/watch?v=${cdsModel.youtubeId}` };
+            const url = this._getUrl(this.atomApiPaths.asset, cdsModel.atomId);
+
+            return this.hmacRequest.post(url, data);
+        });
+    }
+}
+
+module.exports = MediaAtom;

--- a/CDS/scripts/js_utils/media-atom/model/cds-model.js
+++ b/CDS/scripts/js_utils/media-atom/model/cds-model.js
@@ -1,0 +1,55 @@
+class CdsModel {
+    constructor (database) {
+        this.database = database;
+    }
+
+    getData () {
+        return Promise.all([
+            this.database.getOne('meta', 'gnm_master_mediaatom_atomid'), // field name defined in Pluto
+            this.database.getOne('meta', 'itemId'), // field name defined in Pluto
+            this.database.getOne('meta', 'atom_channelId'),
+            this.database.getOne('meta', 'atom_title'),
+            this.database.getOne('meta', 'atom_ytCategory'),
+            this.database.getOne('meta', 'atom_privacyStatus'),
+            this.database.getOne('meta', 'atom_tags'),
+            this.database.getOne('meta', 'atom_posterImage'),
+            this.database.getOne('meta', 'atom_youtubeId')
+
+        ]).then(data => {
+           const [atomId, plutoId, channelId, title, category, privacyStatus, tags, posterImage, youtubeId] = data.map(d => d.value);
+
+           return  {
+               atomId: atomId,
+               plutoId: plutoId,
+               channelId: channelId,
+               title: title,
+               category: category,
+               privacyStatus: privacyStatus,
+               tags: tags,
+               posterImage: posterImage,
+               youtubeId: youtubeId
+           };
+        });
+    }
+
+    saveAtomModel (mediaAtomModel) {
+        const metadata = {
+            atom_channelId: mediaAtomModel.channelId,
+            atom_title: mediaAtomModel.title,
+            atom_ytCategory: mediaAtomModel.categoryId,
+            atom_privacyStatus: mediaAtomModel.privacyStatus || 'Unlisted'
+        };
+
+        if (mediaAtomModel.tags) {
+            metadata.atom_tags = mediaAtomModel.tags;
+        }
+
+        if (mediaAtomModel.posterImage) {
+            metadata.atom_posterImage = mediaAtomModel.posterImage;
+        }
+
+        return this.database.setMany('meta', metadata);
+    }
+}
+
+module.exports = CdsModel;

--- a/CDS/scripts/js_utils/media-atom/model/media-atom-model.js
+++ b/CDS/scripts/js_utils/media-atom/model/media-atom-model.js
@@ -1,0 +1,64 @@
+class MediaAtomModel {
+    constructor (apiResponse) {
+        this._data = apiResponse;
+
+        this.requiredFieldsFromAtom = ['channelId', 'title', 'youtubeCategoryId'];
+
+        this.maxPosterImageFileSize = 2 * 1000 * 1000; // 2MB
+    }
+
+    validate () {
+        return new Promise ((resolve, reject) => {
+            const missingFields = this.requiredFieldsFromAtom.reduce((missing, field) => {
+                if (! Object.keys(this._data).includes(field)) {
+                    missing.push(field);
+                }
+                return missing;
+            }, []);
+
+            if (missingFields.length === 0) {
+                resolve(this);
+            } else {
+                reject(missingFields);
+            }
+        });
+    }
+
+    get id () {
+        return this._data.id;
+    }
+
+    get channelId () {
+        return this._data.channelId;
+    }
+
+    get title () {
+        return this._data.title;
+    }
+
+    get categoryId () {
+        return this._data.youtubeCategoryId;
+    }
+
+    get tags () {
+        return !! this._data.tags && this._data.tags.join(',');
+    }
+
+    get posterImage () {
+        if (this._data.posterImage) {
+            const posterCandidates = this._data.posterImage.assets
+                .sort((p1, p2) => { return p2.size - p1.size; })
+                .filter(p => p.size < this.maxPosterImageFileSize);
+
+            if (posterCandidates.length > 0) {
+                return posterCandidates[0].file;
+            }
+        }
+    }
+
+    get privacyStatus () {
+        return this._data.privacyStatus;
+    }
+}
+
+module.exports = MediaAtomModel;

--- a/CDS/scripts/js_utils/test/data/config.conf
+++ b/CDS/scripts/js_utils/test/data/config.conf
@@ -2,3 +2,5 @@
 username = foo
 password = bar
 something_else = baz
+shared_secret = CanYouKeepASecret
+media_atom_url_base = https://no.where

--- a/CDS/scripts/js_utils/test/datastore/config.js
+++ b/CDS/scripts/js_utils/test/datastore/config.js
@@ -11,7 +11,9 @@ describe('DataStore Config', () => {
         const expected = {
             username: 'foo',
             password: 'bar',
-            something_else: 'baz'
+            something_else: 'baz',
+            shared_secret: 'CanYouKeepASecret',
+            media_atom_url_base: 'https://no.where'
         };
 
         const actual = c.config;
@@ -31,6 +33,8 @@ describe('DataStore Config', () => {
             username: 'foo',
             password: 'bar',
             something_else: 'baz',
+            shared_secret: 'CanYouKeepASecret',
+            media_atom_url_base: 'https://no.where',
             year: 2016,
             month: 1,
             day: 1,

--- a/CDS/scripts/js_utils/test/media-atom/media-atom.js
+++ b/CDS/scripts/js_utils/test/media-atom/media-atom.js
@@ -1,0 +1,211 @@
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const nock = require('nock');
+
+const Config = require('../../datastore/config');
+const Database = require('../../datastore/db');
+const DatabaseInit = require('../../datastore/db-init');
+const HMACRequest = require('../../media-atom/hmac');
+const CdsModel = require('../../media-atom/model/cds-model');
+const MediaAtom = require('../../media-atom/media-atom');
+
+const dataDir = path.join(__dirname, '../data');
+const dbPath = path.join(__dirname, '../data/test.db');
+
+function safeRemoveFile(path) {
+    return new Promise(resolve => {
+        if (! fs.existsSync(path)) {
+            resolve();
+        }
+        fs.unlink(path, () => resolve());
+    });
+}
+
+const URL_BASE = 'https://no.where';
+const ATOM_ID = '123';
+
+describe('MediaAtom', () => {
+    beforeEach(function (done) {
+        safeRemoveFile(dbPath).then(() => {
+            new DatabaseInit(dbPath).then(function () {
+                this.configObj = new Config(dataDir);
+
+                this.hmacRequest = new HMACRequest(this.configObj);
+                this.database = new Database('test', dbPath);
+
+                // seed database with an atomId
+                this.database.setOne('meta', 'gnm_master_mediaatom_atomid', ATOM_ID).then(() => {
+                    this.cdsModel = new CdsModel(database);
+                    done();
+                });
+            });
+        });
+    });
+
+    afterEach(function (done) {
+        safeRemoveFile(dbPath).then(() => done());
+    });
+
+    it('should throw an exception if required env config is missing', function (done) {
+        try {
+            const brokenConfigObj = new Config(dataDir);
+            delete brokenConfigObj.config.media_atom_url_base;
+
+            new MediaAtom(cdsModel, brokenConfigObj, hmacRequest);
+        } catch (e) {
+            assert.ok(e === 'Invalid Config. Missing media_atom_url_base');
+            done();
+        }
+    });
+
+    it('should fetch metadata from media atom but fail when metadata is missing', function (done) {
+        const atomApi = `/api2/atoms/${ATOM_ID}`;
+
+        nock(URL_BASE).get(atomApi).reply(200, {
+            title: 'foo',
+            channelId: 'ChannelOne'
+        });
+
+        const mediaAtom = new MediaAtom(cdsModel, configObj, hmacRequest);
+
+        mediaAtom.fetchAndSaveMetadata().catch(actual => {
+            assert.ok(actual === 'Invalid response from Atom API. Missing youtubeCategoryId');
+            done();
+        })
+    });
+
+    it('should fetch metadata from media atom and save it', function (done) {
+        const atomApi = `/api2/atoms/${ATOM_ID}`;
+
+        nock(URL_BASE).get(atomApi).reply(200, {
+            title: 'foo',
+            channelId: 'ChannelOne',
+            youtubeCategoryId: '1',
+            tags: ['tag', 'team']
+        });
+
+        const mediaAtom = new MediaAtom(cdsModel, configObj, hmacRequest);
+
+        mediaAtom.fetchAndSaveMetadata().then(() => {
+           Promise.all([
+               database.getOne('meta', 'atom_channelId'),
+               database.getOne('meta', 'atom_title'),
+               database.getOne('meta', 'atom_ytCategory'),
+               database.getOne('meta', 'atom_tags')
+           ]).then(actual => {
+              const expected = [
+                  { type: 'meta', key: 'atom_channelId', value: 'ChannelOne' },
+                  { type: 'meta', key: 'atom_title', value: 'foo' },
+                  { type: 'meta', key: 'atom_ytCategory', value: '1' },
+                  { type: 'meta', key: 'atom_tags', value: 'tag,team' }
+              ];
+
+              assert.deepEqual(actual, expected);
+              done();
+           });
+        }).catch(e => new Error(e));
+    });
+
+    it('should fetch metadata and save the best poster image under 2MB', function (done) {
+        const atomApi = `/api2/atoms/${ATOM_ID}`;
+
+        nock(URL_BASE).get(atomApi).reply(200, {
+            title: 'foo',
+            channelId: 'ChannelOne',
+            youtubeCategoryId: '1',
+            posterImage: {
+                assets: [{
+                    mimeType: "image/jpeg",
+                    file: "https://media.guim.co.uk/4d7c1db00237690e268015c5fd09502c66cdfd34/0_64_3488_1962/140.jpg",
+                    dimensions: { height: 79, width: 140 },
+                    size: 7324
+                }, {
+                    mimeType: "image/jpeg",
+                    file: "https://media.guim.co.uk/4d7c1db00237690e268015c5fd09502c66cdfd34/0_64_3488_1962/2000.jpg",
+                    dimensions: { height: 1125, width: 2000 },
+                    size: 218024
+                }, {
+                    mimeType: "image/jpeg",
+                    file: "https://media.guim.co.uk/4d7c1db00237690e268015c5fd09502c66cdfd34/0_64_3488_1962/500.jpg",
+                    dimensions: { height: 281, width: 500 },
+                    size: 32557
+                }, {
+                    mimeType: "image/jpeg",
+                    file: "https://media.guim.co.uk/4d7c1db00237690e268015c5fd09502c66cdfd34/0_64_3488_1962/3488.jpg",
+                    dimensions: { height: 1962, width: 3488 },
+                    size: 460127
+                }, {
+                    mimeType: "image/jpeg",
+                    file: "https://media.guim.co.uk/4d7c1db00237690e268015c5fd09502c66cdfd34/0_64_3488_1962/1000.jpg",
+                    dimensions: { height: 563, width: 1000 },
+                    size: 85022
+                }]
+            }
+        });
+
+        const mediaAtom = new MediaAtom(cdsModel, configObj, hmacRequest);
+
+        mediaAtom.fetchAndSaveMetadata().then(() => {
+            database.getOne('meta', 'atom_posterImage').then(actual => {
+                const expected = {
+                    type: 'meta',
+                    key: 'atom_posterImage',
+                    value: 'https://media.guim.co.uk/4d7c1db00237690e268015c5fd09502c66cdfd34/0_64_3488_1962/3488.jpg'
+                };
+
+                assert.deepEqual(actual, expected);
+                done();
+            }).catch(e => console.log(e));
+        });
+    });
+
+    it('should activate an asset in media atom, but fail when the video encoding takes too long', function (done) {
+        const atomApi = `/api2/atom/${ATOM_ID}/asset-active`;
+
+        nock(URL_BASE).put(atomApi).reply(400);
+
+        const pollDuration = 500; // ms
+        const pollInterval = 100; // ms
+
+        const mediaAtom = new MediaAtom(cdsModel, configObj, hmacRequest, pollDuration, pollInterval);
+
+        database.setOne('meta', 'atom_youtubeId', 'VideoOne').then(() => {
+            mediaAtom.activateAsset().catch(e => {
+                assert.ok(e === 'Cannot add asset to youtube, video encoding took too long');
+                done();
+            });
+        });
+    });
+
+    it('should activate an asset in media atom, polling as it does so', function (done) {
+        const atomApi = `/api2/atom/${ATOM_ID}/asset-active`;
+
+        const pollDuration = 1000;
+        const pollInterval = 100;
+
+        nock(URL_BASE)
+            .put(atomApi).delay(50).reply(400)
+            .put(atomApi).delay(50).reply(400)
+            .put(atomApi).reply(200, 'asset-activated');
+
+        const mediaAtom = new MediaAtom(cdsModel, configObj, hmacRequest, pollDuration, pollInterval);
+
+        database.setOne('meta', 'atom_youtubeId', 'VideoOne').then(() => {
+            mediaAtom.activateAsset().then(actual => {
+                assert.ok(actual.response === 'asset-activated');
+                done();
+            }).catch(e => {
+                done(new Error(e));
+            });
+        });
+    });
+
+    it('should fail to activate an asset if no atom_youtubeId has not been set in the database', function (done) {
+        const mediaAtom = new MediaAtom(cdsModel, configObj, hmacRequest);
+        mediaAtom.activateAsset().catch(actual => {
+            assert.ok(actual === 'Failed to get youtubeId from database');
+            done();
+        });
+    });
+});

--- a/CDS/scripts/js_utils/test/media-atom/model/cds-model.js
+++ b/CDS/scripts/js_utils/test/media-atom/model/cds-model.js
@@ -1,0 +1,58 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const DatabaseInit = require('../../../datastore/db-init');
+const Database = require('../../../datastore/db');
+const CdsModel = require('../../../media-atom/model/cds-model');
+
+const dbPath = path.join(__dirname, '../../data/test.db');
+
+function safeRemoveFile(path) {
+    return new Promise(resolve => {
+        if (! fs.existsSync(path)) {
+            resolve();
+        }
+        fs.unlink(path, () => resolve());
+    });
+}
+
+// TODO these are unit tests. Are they needed? Or are the itegration tests enough?
+describe('CdsModel', () => {
+    beforeEach((done) => {
+        safeRemoveFile(dbPath).then(() => {
+            new DatabaseInit(dbPath).then(() => done());
+        });
+    });
+
+    afterEach((done) => {
+        safeRemoveFile(dbPath).then(() => done());
+    });
+
+    it('should return an object that always has an atomId', function (done) {
+        // this state would occur before `MediaAtom.fetchMetadata` has run.
+
+        const db = new Database('test', dbPath);
+
+        db.setOne('meta', 'gnm_master_mediaatom_atomid', 'AtomOne').then(() => {
+            const cdsModel = new CdsModel(db);
+
+            cdsModel.getData().then(actual => {
+                const expected = {
+                    atomId: 'AtomOne',
+                    plutoId: undefined,
+                    channelId: undefined,
+                    title: undefined,
+                    category: undefined,
+                    privacyStatus: undefined,
+                    tags: undefined,
+                    posterImage: undefined,
+                    youtubeId: undefined
+                };
+
+                assert.deepEqual(actual, expected);
+                done();
+            });
+        });
+    });
+});

--- a/CDS/scripts/js_utils/test/media-atom/model/media-atom-model.js
+++ b/CDS/scripts/js_utils/test/media-atom/model/media-atom-model.js
@@ -1,0 +1,68 @@
+const assert = require('assert');
+const MediaAtomModel = require('../../../media-atom/model/media-atom-model');
+
+describe('MediaAtomModel', () => {
+    before(function (done) {
+        this.badApiResponse = {
+            channelId: 'ChannelOne',
+            tags: ['mic', 'check', 'one', 'two']
+        };
+
+        this.goodApiResponse = {
+            title: 'foo',
+            channelId: 'ChannelOne',
+            youtubeCategoryId: '1',
+            posterImage: {
+                assets: [{
+                    mimeType: "image/jpeg",
+                    file: "https://media.guim.co.uk/4d7c1db00237690e268015c5fd09502c66cdfd34/0_64_3488_1962/140.jpg",
+                    dimensions: { height: 79, width: 140 },
+                    size: 7324
+                }, {
+                    mimeType: "image/jpeg",
+                    file: "https://media.guim.co.uk/4d7c1db00237690e268015c5fd09502c66cdfd34/0_64_3488_1962/2000.jpg",
+                    dimensions: { height: 1125, width: 2000 },
+                    size: 218024
+                }, {
+                    mimeType: "image/jpeg",
+                    file: "https://media.guim.co.uk/4d7c1db00237690e268015c5fd09502c66cdfd34/0_64_3488_1962/500.jpg",
+                    dimensions: { height: 281, width: 500 },
+                    size: 32557
+                }, {
+                    mimeType: "image/jpeg",
+                    file: "https://media.guim.co.uk/4d7c1db00237690e268015c5fd09502c66cdfd34/0_64_3488_1962/3488.jpg",
+                    dimensions: { height: 1962, width: 3488 },
+                    size: 460127
+                }, {
+                    mimeType: "image/jpeg",
+                    file: "https://media.guim.co.uk/4d7c1db00237690e268015c5fd09502c66cdfd34/0_64_3488_1962/1000.jpg",
+                    dimensions: { height: 563, width: 1000 },
+                    size: 85022
+                }]
+            }
+        };
+
+        done();
+    });
+
+    it('should fail to validate when required fields are missing', function (done) {
+        const model = new MediaAtomModel(this.badApiResponse);
+
+        model.validate().then(e => console.log(e)).catch(actual => {
+            const expected = ['title', 'youtubeCategoryId'];
+
+            assert.deepEqual(actual, expected);
+            done();
+        });
+    });
+
+    it('should return the best poster image under 2MB', function (done) {
+        const model = new MediaAtomModel(this.goodApiResponse);
+
+        const actual = model.posterImage;
+        const expected = 'https://media.guim.co.uk/4d7c1db00237690e268015c5fd09502c66cdfd34/0_64_3488_1962/3488.jpg';
+
+        assert.equal(actual, expected);
+        done();
+    });
+});


### PR DESCRIPTION
builds on #53

refactors media-atom-lib.js and hmac.js to be ES6 classes, making use of the database and config classes in #51 and #53