### PR TITLE
Update to link with new media-atom end-point

### DIFF
--- a/CDS/scripts/js_utils/media-atom/media-atom.js
+++ b/CDS/scripts/js_utils/media-atom/media-atom.js
@@ -11,7 +11,7 @@ class MediaAtom {
             asset: '/api2/atoms/:id/assets',
             metadata: '/api2/atoms/:id',
             activateAsset: '/api2/atom/:id/asset-active',
-            updateMetadata: '/api/atom/:id/update-metadata'
+            setPlutoId: '/api2/atom/:id/pluto-id'
         };
 
         this.apiPollDuration = apiPollDuration;
@@ -124,7 +124,7 @@ class MediaAtom {
                 }
 
                 const data = { plutoId: cdsModel.plutoId };
-                const url = this._getUrl(this.atomApiPaths.updateMetadata, cdsModel.atomId);
+                const url = this._getUrl(this.atomApiPaths.setPlutoId, cdsModel.atomId);
 
                 this.hmacRequest.put(url, data).then(response => {
                     Logger.info(`Added plutoId ${cdsModel.plutoId} to atom ${cdsModel.atomId}`);


### PR DESCRIPTION
https://github.com/guardian/media-atom-maker/pull/227 updates the media atom maker, removing a general metadata update end-point and replacing it with one just for updating the pluto ID.

This PR is the corresponding change in CDS.