### PR TITLE
DA Remove 'my' from Broken Line

### DIFF
--- a/CDS/CDS/Datastore.pm
+++ b/CDS/CDS/Datastore.pm
@@ -541,7 +541,7 @@ $hour=sprintf("%02d",$hour);
 $min=sprintf("%02d",$min);
 $sec=sprintf("%02d",$sec);
 
-my $_=$string;
+$_=$string;
 s/{year}/$year/g;
 s/{month}/$mon/g;
 s/{day}/$mday/g;


### PR DESCRIPTION
Fixes broken line.

Tested on a machine running Mac OS 10.5.8.

@fredex42 