### PR TITLE
DA Fix Dailymotion Holding Image with URL from CAPI

### DIFF
--- a/CDS/scripts/dailymotion_upload.pl
+++ b/CDS/scripts/dailymotion_upload.pl
@@ -363,11 +363,16 @@ if ($store->substitute_string($ENV{'video_adult'}) eq "contains_adult_content") 
 	$adult = 'true';
 }
 
+my $ua = LWP::UserAgent->new;
+my $req = $ua->request(GET 'https://internal.content.guardianapis.com/atom/media/'.$store->substitute_string($ENV{'atom_id'}));
+
+my $capi = decode_json($req->content);
+
 print "INFO: Logging in to Daily Motion\n";
 my $file, $result, $message;
 
 
-my $ua = LWP::UserAgent->new;
+
 my $req = $ua->request(POST 'https://api.dailymotion.com/oauth/token',
 	  Content_Type => 'application/x-www-form-urlencoded',
 	  Content => [
@@ -473,8 +478,8 @@ my $content = {
 	access_token => $server->{'access_token'}
 };
 			  
-if (is_imageurl_valid($imageurl)) {
-	$content->{'thumbnail_url'} = $imageurl;
+if (is_imageurl_valid($capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'master'}->{'file'})) {
+	$content->{'thumbnail_url'} = $capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'master'}->{'file'};
 }
 
 my $req;


### PR DESCRIPTION
Some code which uses the Atom id. to poll CAPI for an image URL.

This image URL is then used in the Dailymotion upload.

Tested on the dev. system.

@fredex42 