### PR TITLE
Access of CAPI To Use Key

### DIFF
--- a/CDS/scripts/atom_image.pl
+++ b/CDS/scripts/atom_image.pl
@@ -46,7 +46,7 @@ if(defined $ENV{'sleep_delay'}){
 
 my $response;
 while(true) {
-	$response = $ua->request(GET 'https://internal.content.guardianapis.com/atom/media/'.$store->substitute_string($ENV{'atom_id'}));
+	$response = $ua->request(GET 'https://content.guardianapis.com/atom/media/'.$store->substitute_string($ENV{'atom_id'}).'?api-key='.$store->substitute_string($ENV{'api_key'}));
 	if($response->code >=400 && $response->code <=499){
 		print $response->content;
 		print "\n-ERROR: CAPI returned " . $response->code . ", actual error is logged above.\n";

--- a/CDS/scripts/dailymotion_upload.pl
+++ b/CDS/scripts/dailymotion_upload.pl
@@ -364,7 +364,7 @@ if ($store->substitute_string($ENV{'video_adult'}) eq "contains_adult_content") 
 }
 
 my $ua = LWP::UserAgent->new;
-my $req = $ua->request(GET 'https://internal.content.guardianapis.com/atom/media/'.$store->substitute_string($ENV{'atom_id'}));
+my $req = $ua->request(GET 'https://content.guardianapis.com/atom/media/'.$store->substitute_string($ENV{'atom_id'}).'?api-key='.$store->substitute_string($ENV{'api_key'}));
 
 my $capi = decode_json($req->content);
 


### PR DESCRIPTION
CAPI has been changed and now requires use of an API key. This change makes the scripts that talk to CAPI access it using a key supplied from the config. route XML file via the tag 'api_key'.

@fredex42 