### PR TITLE
atom_image.pl to Have Optional Configurable Maximum Dimensions and dailymotion_upload.pl to Use the Output from atom_image.pl

### DIFF
--- a/CDS/scripts/atom_image.pl
+++ b/CDS/scripts/atom_image.pl
@@ -78,7 +78,8 @@ if(defined $ENV{'output-smaller-than'}){
   my $max_width = $store->substitute_string($ENV{'output-smaller-than-width'});
   my $assets = $capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'assets'};
   my $match = undef;
-  foreach(@{$assets}){
+  my @sorted_assets = sort { $b->{'dimensions'}->{'height'} <=> $a->{'dimensions'}->{'height'} } @{$assets};
+  foreach(@sorted_assets){
     my $current_asset = $_;
     next if(not defined $current_asset->{'file'});
     if($current_asset->{'dimensions'}->{'height'} < $max_height and $current_asset->{'dimensions'}->{'width'} < $max_width){

--- a/CDS/scripts/atom_image.pl
+++ b/CDS/scripts/atom_image.pl
@@ -5,6 +5,9 @@
 # <atom_id> - the Atom id. of the video
 # <max_retries> - maximum number of times to try connecting to CAPI 
 # <sleep_delay> - number of seconds to wait before each retry
+# <output-smaller-than/> - If present then script will attempt to find an image smaller than the supplied dimensions
+# <output-smaller-than-height> - Integer - Find an image smaller than this in height
+# <output-smaller-than-width> - Integer - Find an image smaller than this in width
 
 #END DOC
   

--- a/CDS/scripts/atom_image.pl
+++ b/CDS/scripts/atom_image.pl
@@ -74,19 +74,21 @@ if(defined $ENV{'output-smaller-than'}){
   my %image_urls;
   my $image_place = 0;
   while($image_place < 20) {
-    if ($capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'assets'}->{$image_place}->{'dimensions'}->{'height'} < $store->substitute_string($ENV{'output-smaller-than-height'}) {
-      if ($capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'assets'}->{$image_place}->{'dimensions'}->{'width'} < $store->substitute_string($ENV{'output-smaller-than-width'}) {
-        $image_urls{$image_place} = $capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'assets'}->{$image_place}->{'dimensions'}->{'width'};
+    if (defined $capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'assets'}[$image_place]->{'file'}) {
+      if ($capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'assets'}[$image_place]->{'dimensions'}->{'height'} < $store->substitute_string($ENV{'output-smaller-than-height'})) {
+        if ($capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'assets'}[$image_place]->{'dimensions'}->{'width'} < $store->substitute_string($ENV{'output-smaller-than-width'})) {
+          $image_urls{$image_place} = $capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'assets'}[$image_place]->{'dimensions'}->{'width'};
+        }
       }
     }
     $image_place = $image_place + 1;
   }
-  my @image_urls_sorted = sort {$b <=> $a} (values %image_urls);
-  unless (is_imageurl_valid($capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'assets'}->{@image_urls_sorted[0]}->{'file'})) {
+  my @image_urls_sorted = sort {$b <=> $a} (keys %image_urls);
+  unless (is_imageurl_valid($capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'assets'}[@image_urls_sorted[0]]->{'file'})) {
   	exit(1);
   }
-  print "INFO: Outputting image URL ".$capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'assets'}->{@image_urls_sorted[0]}->{'file'}."\n";
-  $store->set('meta','atom_image_url',$capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'assets'}->{@image_urls_sorted[0]}->{'file'});
+  print "INFO: Outputting image URL ".$capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'assets'}[@image_urls_sorted[0]]->{'file'}."\n";
+  $store->set('meta','atom_image_url',$capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'assets'}[@image_urls_sorted[0]]->{'file'});
 } else {
   unless (is_imageurl_valid($capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'master'}->{'file'})) {
   	exit(1);

--- a/CDS/scripts/atom_image.pl
+++ b/CDS/scripts/atom_image.pl
@@ -70,12 +70,29 @@ while(true) {
 
 my $capi = decode_json($response->content);
 
-unless (is_imageurl_valid($capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'master'}->{'file'})) {
-	exit(1);
+if(defined $ENV{'output-smaller-than'}){
+  my %image_urls;
+  my $image_place = 0;
+  while($image_place < 20) {
+    if ($capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'assets'}->{$image_place}->{'dimensions'}->{'height'} < $store->substitute_string($ENV{'output-smaller-than-height'}) {
+      if ($capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'assets'}->{$image_place}->{'dimensions'}->{'width'} < $store->substitute_string($ENV{'output-smaller-than-width'}) {
+        $image_urls{$image_place} = $capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'assets'}->{$image_place}->{'dimensions'}->{'width'};
+      }
+    }
+    $image_place = $image_place + 1;
+  }
+  my @image_urls_sorted = sort {$b <=> $a} (values %image_urls);
+  unless (is_imageurl_valid($capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'assets'}->{@image_urls_sorted[0]}->{'file'})) {
+  	exit(1);
+  }
+  print "INFO: Outputting image URL ".$capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'assets'}->{@image_urls_sorted[0]}->{'file'}."\n";
+  $store->set('meta','atom_image_url',$capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'assets'}->{@image_urls_sorted[0]}->{'file'});
+} else {
+  unless (is_imageurl_valid($capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'master'}->{'file'})) {
+  	exit(1);
+  }
+  print "INFO: Outputting image URL ".$capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'master'}->{'file'}."\n";
+  $store->set('meta','atom_image_url',$capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'master'}->{'file'});
 }
-
-print "INFO: Outputting image URL ".$capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'master'}->{'file'}."\n";
-
-$store->set('meta','atom_image_url',$capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'master'}->{'file'});
 
 print "+SUCCESS: URL acquired\n";

--- a/CDS/scripts/dailymotion_upload.pl
+++ b/CDS/scripts/dailymotion_upload.pl
@@ -363,11 +363,6 @@ if ($store->substitute_string($ENV{'video_adult'}) eq "contains_adult_content") 
 	$adult = 'true';
 }
 
-my $ua = LWP::UserAgent->new;
-my $req = $ua->request(GET 'https://content.guardianapis.com/atom/media/'.$store->substitute_string($ENV{'atom_id'}).'?api-key='.$store->substitute_string($ENV{'api_key'}));
-
-my $capi = decode_json($req->content);
-
 print "INFO: Logging in to Daily Motion\n";
 my $file, $result, $message;
 
@@ -477,9 +472,9 @@ my $content = {
 	language	 => $videolanguage,
 	access_token => $server->{'access_token'}
 };
-			  
-if (is_imageurl_valid($capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'master'}->{'file'})) {
-	$content->{'thumbnail_url'} = $capi->{'response'}->{'media'}->{'data'}->{'media'}->{'trailImage'}->{'master'}->{'file'};
+
+if (is_imageurl_valid($imageurl)) {
+	$content->{'thumbnail_url'} = $imageurl;
 }
 
 my $req;


### PR DESCRIPTION
You can now set atom_image.pl to only output images smaller than certain dimensions. Syntax: -

```
<output-smaller-than/>
<output-smaller-than-height>4999</output-smaller-than-height>
<output-smaller-than-width>4999</output-smaller-than-width>
```

Also changes dailymotion_upload.pl to use the output from atom_image.pl rather than making its own access to CAPI as it was doing.

Tested on the dev. system.

@fredex42 