### PR TITLE
Check Dates are Before 2008 and Set Them to Current Date/time if They Are

### DIFF
--- a/CDS/scripts/check_date.pl
+++ b/CDS/scripts/check_date.pl
@@ -11,6 +11,7 @@ use CDS::Datastore;
 use File::Slurp qw/read_file/;
 use DateTime::Format::Strptime;
 use DateTime;
+use Date::Manip qw(ParseDate);
 
 #START MAIN
 my $store=CDS::Datastore->new('check_date');
@@ -46,6 +47,11 @@ my $existing_value=$store->get(@keyparts,undef);
 
 my $value=$existing_value;
 my $finalstring=$existing_value;
+my $test_date = ParseDate($value);
+if (!$test_$date) {
+	print "-ERROR - Perl could not parse the supplied string ($value) as a date. Aborting.\n";
+	exit 1;
+}
 my $format = DateTime::Format::Strptime->new( pattern => '%FT%T%z');
 my $date_time_from_datastore = $format->parse_datetime($value);
 my $oldest_allowed_date_time = $format->parse_datetime('2008-01-01T00:00:00');

--- a/CDS/scripts/check_date.pl
+++ b/CDS/scripts/check_date.pl
@@ -56,5 +56,5 @@ if ($date_time_from_datastore < $oldest_allowed_date_time) {
 	$store->set(@keyparts,$finalstring,undef);
 	print "+SUCCESS: Value set.\n";
 } else {
-	print "INFO: Date/time is after midnight on 1/1/2008. Nothing to do.\n"
+	print "INFO: $key is $date_time_from_datestore which is after midnight on 1/1/2008. Leaving alone.\n"
 }

--- a/CDS/scripts/check_date.pl
+++ b/CDS/scripts/check_date.pl
@@ -1,0 +1,60 @@
+#!/usr/bin/perl
+
+my $version='$Rev: 1 $ $LastChangedDate: 2020-05-15 16:06:33 +0100 (Fri, 15 May 2020) $';
+
+#Module to check dates are not before 2008 and set them to the current date/time if they are.
+#Expects:
+#<key>blah 	   - the name of the key to check for the date
+#END DOC
+
+use CDS::Datastore;
+use File::Slurp qw/read_file/;
+use DateTime::Format::Strptime;
+use DateTime;
+
+#START MAIN
+my $store=CDS::Datastore->new('check_date');
+
+$store->{'debug'}=$ENV{'debug'};
+
+foreach(qw/key/){
+	if(not defined $ENV{$_}){
+		print "-ERROR - you need to specify <$_> to use this module.\n";
+		exit 1;
+	}
+}
+
+my $key=$ENV{'key'};
+if($key eq ''){
+	print "-ERROR - you need to specify a value in <key> to set a metadata key.\n";
+	exit 1;
+}
+
+my @keyparts=split /:/,$ENV{'key'};
+#if no section is specified, default to "meta"
+if(scalar @keyparts==1){
+	$keyparts[1]=$ENV{'key'};
+	$keyparts[0]="meta";
+	$key="meta:$key";
+}
+
+if($keyparts[0] eq "track"){
+	splice @keyparts,1,0,'type';
+}
+
+my $existing_value=$store->get(@keyparts,undef);
+
+my $value=$existing_value;
+my $finalstring=$existing_value;
+my $format = DateTime::Format::Strptime->new( pattern => '%FT%T%z');
+my $date_time_from_datastore = $format->parse_datetime($value);
+my $oldest_allowed_date_time = $format->parse_datetime('2008-01-01T00:00:00');
+if ($date_time_from_datastore < $oldest_allowed_date_time) {
+	my $now = DateTime->now()->iso8601().'Z';
+	$finalstring = $now;
+	print "INFO: Setting '$key' to '$finalstring' in the metadata stream...\n";
+	$store->set(@keyparts,$finalstring,undef);
+	print "+SUCCESS: Value set.\n";
+} else {
+	print "INFO: Date/time is after midnight on 1/1/2008. Nothing to do.\n"
+}


### PR DESCRIPTION
Simple method that checks if the given key is a date before midnight on 1/1/2008. If it is, it replaces the key with a string in ISO format representing the current date/time. If a date/time after 1/1/2008 is found the method does nothing apart from print a brief message saying it has nothing to do.