### PR TITLE
Fix Docker Building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:bionic
 
 COPY dockerbuild/base_setup.sh /tmp/dockerbuild/
 RUN bash -e /tmp/dockerbuild/base_setup.sh

--- a/dockerbuild/base_setup.sh
+++ b/dockerbuild/base_setup.sh
@@ -10,10 +10,9 @@ mkdir -p /usr/local/bin
 echo ------------------------------------------
 echo Kickstarter: Installing prerequisites...
 echo ------------------------------------------
-DEBIAN_FRONTEND=noninteractive apt-get -y install python-pip zip perl ffmpeg2theora libz-dev libcrypt-ssleay-perl liburi-encode-perl libnet-ssleay-perl libnet-idn-encode-perl \
+DEBIAN_FRONTEND=noninteractive apt-get -y install zip perl ffmpeg2theora libz-dev libcrypt-ssleay-perl liburi-encode-perl libnet-ssleay-perl libnet-idn-encode-perl \
 liblwp-protocol-https-perl libdbd-sqlite3-perl libyaml-perl libxml-sax-expatxs-perl libxml-xpath-perl libwww-perl libtemplate-perl  \
 libxml-simple-perl libjson-perl libjson-xs-perl libdate-manip-perl libnet-sslglue-perl libdigest-perl libdigest-sha-perl libdatetime-perl libdatetime-format-http-perl \
 libdbi-perl libhtml-stream-perl libfile-slurp-unicode-perl cpanminus zlib1g-dev build-essential s3cmd libsqlite3-dev nodejs curl libdbd-pg-perl libxml2-dev libxslt1-dev imagemagick
-pip --no-cache-dir install awscli
 
 rm -rf /var/cache/apt


### PR DESCRIPTION
python-pip and the Ruby 2.6 images where not compatable with verison 20 of Ubuntu so I have forced Docker to use version 18 of Ubuntu.

Decided to remove python-pip anyway as it was only used to install awscli which is no longer needed.

Tested on the live system.

@fredex42 
