### PR TITLE
Fixes for http_download

### DIFF
--- a/CDS/scripts/http_download.pl
+++ b/CDS/scripts/http_download.pl
@@ -55,7 +55,6 @@ $debug=$ENV{'debug'};
 
 my $url=$store->substitute_string($ENV{'url'});
 my $rawdir = $ENV{'output-directory'};
-#$rawdir = $ENV{'output_directory'} if($rawdir=="");
 
 my $outputdir=$store->substitute_string($rawdir);
 my $outputfile;
@@ -82,7 +81,7 @@ my $ua = LWP::UserAgent->new( ssl_opts => { verify_hostname => 0 });
 my $rc;
 do{
 	++$attempt;
-	$rc=$ua->get($url, ':content_file'=>$outputfile);
+	$rc=$ua->get($url, ':content_file'=>$outputpath);
 	if($rc->is_success) {
 		print "INFO - Downloaded content from $url, saved to $outputpath...\n";
 	} else {

--- a/CDS/scripts/http_download.pl
+++ b/CDS/scripts/http_download.pl
@@ -1,7 +1,5 @@
 #!/usr/bin/perl
 
-my $version='$Rev: 472 $ $LastChangedDate: 2013-08-14 14:25:30 +0100 (Wed, 14 Aug 2013) $';
-
 $|=1;
 #this is a CDS module to pull down media or metadata via HTTP
 #arguments:
@@ -57,7 +55,7 @@ $debug=$ENV{'debug'};
 
 my $url=$store->substitute_string($ENV{'url'});
 my $rawdir = $ENV{'output-directory'};
-$rawdir = $ENV{'output_directory'} if($rawdir=="");
+#$rawdir = $ENV{'output_directory'} if($rawdir=="");
 
 my $outputdir=$store->substitute_string($rawdir);
 my $outputfile;
@@ -81,6 +79,7 @@ print "*MESSAGE - downloading from $url to $outputpath\n";
 
 my $attempt=0;
 my $ua = LWP::UserAgent->new( ssl_opts => { verify_hostname => 0 });
+my $rc;
 do{
 	++$attempt;
 	$rc=$ua->get($url, ':content_file'=>$outputfile);


### PR DESCRIPTION
## What does this change?
Corrects the way that http_download determines paths to ensure that `output-directory` is always respected and the value set for the downloaded file location is actually the location where the file exists

## How to test
Run the Dailymotion route on the dev system on a file originated from media atom, and view the logs.  Check that the file is actually output to disk and that it's picked up and sent to S3

## How can we measure success?
Holding images making it to Daily Motion and Mainstream on the new containerised system

## Have we considered potential risks?
None, this has been tested thoroughly and even when broken it is not vital for output
